### PR TITLE
ghc package does no longer contain cabal

### DIFF
--- a/Haskell/ss-haskell-dev.md
+++ b/Haskell/ss-haskell-dev.md
@@ -36,7 +36,7 @@ workflow, I wanted to get more comfortable with Nix first.*
 file.
 If you already have a cabal file, you can skip this step.
 
-    nix-shell --packages ghc --run 'cabal init'
+    nix-shell --packages ghc --packages cabal-install --run 'cabal init'
 
 2. Create default.nix:
 


### PR DESCRIPTION
I tried your "super-simple" tutorial and it turned out one needs to type a slightly different command to scaffold a cabal project. I guess that 'cabal' tool was a part of 'ghc' in the past.

The change is very small yet I think it's worth including it. In order not to discourage the newbies like me when they see errors in terminal.